### PR TITLE
Add core HabitRPG domain types and formula utilities

### DIFF
--- a/src/lib/formulas.ts
+++ b/src/lib/formulas.ts
@@ -1,0 +1,98 @@
+import type { Monster, Task, TaskPriority, User } from '../types/core';
+
+/**
+ * Precision helper rounding numeric results to two decimal places.
+ */
+const roundToTwo = (value: number): number => Math.round(value * 100) / 100;
+
+const PRIORITY_MULTIPLIER: Record<TaskPriority, number> = {
+  0.1: 0.5,
+  1: 1,
+  1.5: 1.5,
+  2: 2,
+};
+
+/**
+ * Computes the experience required to advance from the provided level
+ * to the next one. The curve mirrors the original Habitica progression
+ * which gently increases the requirement at higher levels while keeping
+ * the early game approachable.
+ *
+ * @param level - Current player level. Negative values are treated as 0.
+ * @returns Required experience rounded to the nearest whole point.
+ */
+export const xpNeededForLevel = (level: number): number => {
+  const normalizedLevel = Math.max(1, Math.floor(level));
+  const xp = 0.25 * Math.pow(normalizedLevel - 1, 2) + 10 * (normalizedLevel - 1) + 139.75;
+  return Math.round(xp);
+};
+
+/**
+ * Calculates the gold and experience awarded for completing a task.
+ * The formula balances task priority, player attribute bonuses and the
+ * current task value which drifts according to repeated completions.
+ *
+ * @param task - The task that was completed.
+ * @param user - The user receiving the reward.
+ * @returns An object containing gold and experience rewards rounded to cents.
+ */
+export const taskRewards = (task: Task, user: User): { gold: number; experience: number } => {
+  const priorityMultiplier = PRIORITY_MULTIPLIER[task.priority] ?? 1;
+  const attributeValue = user.stats[task.attribute];
+  const attributeMultiplier = 1 + attributeValue / 200;
+  const streakModifier = 1 + Math.max(0, task.streak ?? 0) * 0.02;
+  const difficultyModifier = Math.exp(-Math.min(5, Math.max(-5, task.value)) / 10);
+
+  const baseExperience = 10;
+  const baseGold = 1.5;
+
+  const experience = roundToTwo(baseExperience * priorityMultiplier * attributeMultiplier * streakModifier * difficultyModifier);
+  const gold = roundToTwo(baseGold * priorityMultiplier * attributeMultiplier * streakModifier * difficultyModifier);
+
+  return { gold, experience };
+};
+
+/**
+ * Computes the amount of damage a user receives when failing a task or
+ * daily. Constitution mitigates incoming damage while the task's value
+ * and priority increase the penalty for repeated neglect.
+ *
+ * @param task - The failed task.
+ * @param user - The user receiving damage.
+ * @returns Damage rounded to two decimal places.
+ */
+export const damageTaken = (task: Task, user: User): number => {
+  const priorityMultiplier = PRIORITY_MULTIPLIER[task.priority] ?? 1;
+  const taskPenalty = 1 + Math.max(0, -(task.value)) / 5;
+  const conMitigation = 1 - Math.min(0.6, user.stats.con / 200);
+  const streakPenalty = 1 + Math.max(0, (task.streak ?? 0)) * 0.05;
+
+  const baseDamage = task.type === 'daily' ? 10 : task.type === 'habit' ? 6 : 5;
+  const damage = baseDamage * priorityMultiplier * taskPenalty * streakPenalty * conMitigation;
+
+  return roundToTwo(Math.max(0, damage));
+};
+
+/**
+ * Estimates the amount of health damage a player inflicts upon a quest
+ * boss. Strength and perception contribute to the offensive score while
+ * monster defense reduces the final amount.
+ *
+ * @param user - The attacking player.
+ * @param monster - The monster targeted by the attack.
+ * @returns Damage dealt rounded to two decimal places.
+ */
+export const playerDamage = (user: User, monster: Monster): number => {
+  const offensiveScore = user.stats.str * 0.65 + user.stats.per * 0.35 + user.stats.lvl * 1.5;
+  const equipmentBonus = Object.values(user.items.equipment ?? {}).reduce((total, item) => {
+    if (!item?.bonuses) return total;
+    const { str = 0, per = 0 } = item.bonuses;
+    return total + str * 0.5 + per * 0.25;
+  }, 0);
+
+  const rawDamage = offensiveScore + equipmentBonus;
+  const mitigatedDamage = rawDamage * (1 - Math.min(0.7, monster.defense / 200));
+  const levelScaling = 1 + Math.max(0, user.stats.lvl - 1) / 50;
+
+  return roundToTwo(Math.max(0, mitigatedDamage * levelScaling));
+};

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,0 +1,232 @@
+/**
+ * Core HabitRPG domain types used across calculations and UI helpers.
+ *
+ * Every type in this module is intentionally exhaustive so downstream
+ * consumers can rely on a consistent shape without consulting the API
+ * layer.  All definitions are side-effect free and purely declarative.
+ */
+
+/**
+ * The set of task categories supported by the game.
+ */
+export type TaskType = 'habit' | 'daily' | 'todo' | 'reward';
+
+/**
+ * Allowed priority multipliers for tasks.
+ */
+export type TaskPriority = 0.1 | 1 | 1.5 | 2;
+
+/**
+ * Player attributes a task may target for buff calculations.
+ */
+export type TaskAttribute = 'str' | 'int' | 'con' | 'per';
+
+/**
+ * Individual checklist entry attached to a task.
+ */
+export interface ChecklistItem {
+  /** Stable identifier for the checklist entry. */
+  id: string;
+  /** Checklist description rendered to the user. */
+  text: string;
+  /** Whether the item has been completed. */
+  completed: boolean;
+}
+
+/**
+ * Player facing task definition.
+ */
+export interface Task {
+  /** Unique identifier of the task. */
+  id: string;
+  /** Human readable title. */
+  text: string;
+  /** Optional Markdown notes. */
+  notes?: string;
+  /** Task category. */
+  type: TaskType;
+  /** Difficulty weight selected by the player. */
+  priority: TaskPriority;
+  /** Dynamic scoring value influenced by completions. */
+  value: number;
+  /** Attribute associated with the task. */
+  attribute: TaskAttribute;
+  /** Whether the task is currently due (dailies) or available. */
+  isDue?: boolean;
+  /** Current streak count used for daily/task decay. */
+  streak?: number;
+  /** Nested checklist items. */
+  checklist?: ChecklistItem[];
+  /** Optional tag identifiers applied by the user. */
+  tags?: string[];
+}
+
+/**
+ * Core stat block shared by users and monsters.
+ */
+export interface StatBlock {
+  /** Strength attribute. */
+  str: number;
+  /** Intelligence attribute. */
+  int: number;
+  /** Constitution attribute. */
+  con: number;
+  /** Perception attribute. */
+  per: number;
+}
+
+/**
+ * Summary of the player's current statistics.
+ */
+export interface UserStats extends StatBlock {
+  /** Player level. */
+  lvl: number;
+  /** Current experience points. */
+  exp: number;
+  /** Current health points. */
+  hp: number;
+  /** Maximum health points. */
+  maxHealth: number;
+  /** Current mana points. */
+  mp: number;
+  /** Maximum mana points. */
+  maxMana: number;
+  /** Gold currency owned by the player. */
+  gp: number;
+}
+
+/**
+ * Equipment loadout used when calculating buffs.
+ */
+export interface EquipmentSet {
+  /** Weapon currently equipped. */
+  weapon?: Item;
+  /** Armor currently equipped. */
+  armor?: Item;
+  /** Head gear currently equipped. */
+  head?: Item;
+  /** Off-hand item currently equipped. */
+  shield?: Item;
+  /** Additional costume items by slot. */
+  costume?: Partial<Record<'weapon' | 'armor' | 'head' | 'shield', Item>>;
+}
+
+/**
+ * Representation of a player's inventory.
+ */
+export interface Inventory {
+  /** Owned equipment grouped by slot. */
+  equipment?: EquipmentSet;
+  /** Count of owned materials keyed by item key. */
+  materials?: Record<string, number>;
+  /** Owned pets keyed by identifier. */
+  pets?: Record<string, boolean>;
+  /** Owned mounts keyed by identifier. */
+  mounts?: Record<string, boolean>;
+}
+
+/**
+ * Player profile stored locally.
+ */
+export interface User {
+  /** Unique identifier. */
+  id: string;
+  /** Display name shown to other users. */
+  name: string;
+  /** Current statistic snapshot. */
+  stats: UserStats;
+  /** Inventory collection and equipment. */
+  items: Inventory;
+  /** Tasks owned by the player. */
+  tasks: Task[];
+  /** Earned achievements keyed by identifier. */
+  achievements?: Record<string, Achievement>;
+  /** Active quest participation. */
+  quest?: Quest;
+}
+
+/**
+ * Game item metadata.
+ */
+export interface Item {
+  /** Machine readable key. */
+  key: string;
+  /** Item name. */
+  text: string;
+  /** Optional lore description. */
+  notes?: string;
+  /** Purchase price in gold. */
+  value: number;
+  /** Level requirement for equipping. */
+  levelRequired?: number;
+  /** Primary item category. */
+  type: 'weapon' | 'armor' | 'head' | 'shield' | 'pet' | 'mount' | 'quest' | 'consumable';
+  /** Stat bonuses granted when equipped. */
+  bonuses?: Partial<StatBlock> & { hp?: number; mp?: number };
+}
+
+/**
+ * Monster definition used in quest battles.
+ */
+export interface Monster {
+  /** Unique quest identifier. */
+  key: string;
+  /** Display name. */
+  name: string;
+  /** Current health. */
+  hp: number;
+  /** Maximum health. */
+  maxHealth: number;
+  /** Offensive power influencing damage output. */
+  strength: number;
+  /** Defensive rating reducing player damage. */
+  defense: number;
+}
+
+/**
+ * Rewards granted upon quest completion.
+ */
+export interface QuestRewards {
+  /** Experience points earned. */
+  exp: number;
+  /** Gold earned. */
+  gp: number;
+  /** Item rewards granted. */
+  items?: Item[];
+}
+
+/**
+ * Quest data including optional boss fights and drops.
+ */
+export interface Quest {
+  /** Quest identifier. */
+  key: string;
+  /** Quest title. */
+  title: string;
+  /** Narrative description. */
+  description: string;
+  /** Boss associated with the quest, if any. */
+  boss?: Monster;
+  /** Collectable items required for completion. */
+  collect?: Record<string, number>;
+  /** Rewards distributed on success. */
+  rewards: QuestRewards;
+}
+
+/**
+ * Achievement progress tracker.
+ */
+export interface Achievement {
+  /** Machine readable identifier. */
+  key: string;
+  /** Title displayed to the player. */
+  title: string;
+  /** Description or unlock text. */
+  text: string;
+  /** Whether the achievement has been earned. */
+  earned: boolean;
+  /** Optional timestamp for when the achievement was unlocked. */
+  earnedOn?: string;
+}
+
+export type { Task as HabitTask, User as HabitUser, Item as HabitItem, Monster as HabitMonster, Quest as HabitQuest, Achievement as HabitAchievement };


### PR DESCRIPTION
## Summary
- add comprehensive core type definitions covering tasks, users, items, monsters, quests, and achievements
- implement reusable formula helpers for experience, rewards, and combat calculations with documentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0dbcf51d883259b52abb0af976b8e