### PR TITLE
Add Zustand stores and persistence layer

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,14 @@
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { loadInventoryState, loadUserState, saveInventoryState, saveUserState } from '@/src/lib/persistence';
+import { getInventorySnapshot, useInventoryStore } from '@/src/lib/store/inventoryStore';
+import { getUserSnapshot, useUserStore } from '@/src/lib/store/userStore';
 
 export const unstable_settings = {
   anchor: '(tabs)',
@@ -11,6 +16,59 @@ export const unstable_settings = {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const hydrateStores = async () => {
+      try {
+        const [user, inventory] = await Promise.all([
+          loadUserState(),
+          loadInventoryState(),
+        ]);
+
+        if (user) {
+          useUserStore.getState().hydrate(user);
+        }
+
+        if (inventory) {
+          useInventoryStore.getState().hydrate(inventory);
+        }
+      } catch (error) {
+        console.error('Failed to hydrate stores', error);
+      } finally {
+        setIsHydrated(true);
+      }
+    };
+
+    void hydrateStores();
+  }, []);
+
+  useEffect(() => {
+    if (!isHydrated) {
+      return;
+    }
+
+    const unsubscribeUser = useUserStore.subscribe((state) => {
+      void saveUserState(getUserSnapshot(state));
+    });
+
+    const unsubscribeInventory = useInventoryStore.subscribe((state) => {
+      void saveInventoryState(getInventorySnapshot(state));
+    });
+
+    return () => {
+      unsubscribeUser();
+      unsubscribeInventory();
+    };
+  }, [isHydrated]);
+
+  if (!isHydrated) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@react-native-async-storage/async-storage": "^2.1.1",
     "expo": "~54.0.12",
     "expo-constants": "~18.0.9",
     "expo-font": "~14.0.8",
@@ -35,7 +36,8 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -1,0 +1,64 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { InventorySnapshot } from './store/inventoryStore';
+import type { UserSnapshot } from './store/userStore';
+
+export interface TaskSnapshot {
+  id: string;
+  title: string;
+  type: 'habit' | 'daily' | 'todo';
+  completed: boolean;
+  notes?: string;
+}
+
+const STORAGE_KEYS = {
+  user: 'habit:user',
+  inventory: 'habit:inventory',
+  tasks: 'habit:tasks',
+} as const;
+
+const serialize = <T>(value: T) => JSON.stringify(value);
+
+const deserialize = <T>(value: string | null): T | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    console.warn('Failed to parse persisted state', error);
+    return undefined;
+  }
+};
+
+export const loadUserState = async (): Promise<UserSnapshot | undefined> => {
+  const value = await AsyncStorage.getItem(STORAGE_KEYS.user);
+  return deserialize<UserSnapshot>(value);
+};
+
+export const saveUserState = async (snapshot: UserSnapshot): Promise<void> => {
+  await AsyncStorage.setItem(STORAGE_KEYS.user, serialize(snapshot));
+};
+
+export const loadInventoryState = async (): Promise<InventorySnapshot | undefined> => {
+  const value = await AsyncStorage.getItem(STORAGE_KEYS.inventory);
+  return deserialize<InventorySnapshot>(value);
+};
+
+export const saveInventoryState = async (snapshot: InventorySnapshot): Promise<void> => {
+  await AsyncStorage.setItem(STORAGE_KEYS.inventory, serialize(snapshot));
+};
+
+export const loadTasks = async (): Promise<TaskSnapshot[] | undefined> => {
+  const value = await AsyncStorage.getItem(STORAGE_KEYS.tasks);
+  return deserialize<TaskSnapshot[]>(value);
+};
+
+export const saveTasks = async (tasks: TaskSnapshot[]): Promise<void> => {
+  await AsyncStorage.setItem(STORAGE_KEYS.tasks, serialize(tasks));
+};
+
+export const clearPersistence = async () => {
+  await AsyncStorage.multiRemove(Object.values(STORAGE_KEYS));
+};

--- a/src/lib/store/inventoryStore.ts
+++ b/src/lib/store/inventoryStore.ts
@@ -1,0 +1,200 @@
+import { create } from 'zustand';
+
+import { useUserStore, type EquipmentSlot } from './userStore';
+
+export type ConsumableEffectType = 'heal' | 'xp' | 'coins';
+
+export interface ConsumableEffect {
+  type: ConsumableEffectType;
+  amount: number;
+}
+
+export interface BaseItem {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface ConsumableItem extends BaseItem {
+  type: 'consumable';
+  effect: ConsumableEffect;
+}
+
+export interface EquipmentItem extends BaseItem {
+  type: 'equipment';
+  slot: EquipmentSlot;
+}
+
+export type InventoryItem = ConsumableItem | EquipmentItem;
+
+export interface InventoryEntry {
+  item: InventoryItem;
+  quantity: number;
+}
+
+export type InventoryCollection = Record<string, InventoryEntry>;
+
+export interface InventorySnapshot {
+  items: InventoryCollection;
+}
+
+interface InventoryActions {
+  addItem: (item: InventoryItem, quantity?: number) => void;
+  removeItem: (itemId: string, quantity?: number) => void;
+  useItem: (itemId: string) => boolean;
+  equipItem: (itemId: string) => boolean;
+  unequip: (slot: EquipmentSlot) => void;
+  hydrate: (snapshot: InventorySnapshot) => void;
+  reset: () => void;
+}
+
+export type InventoryState = InventorySnapshot & InventoryActions;
+
+const initialSnapshot: InventorySnapshot = {
+  items: {},
+};
+
+const applyConsumableEffect = (effect: ConsumableEffect) => {
+  const user = useUserStore.getState();
+
+  switch (effect.type) {
+    case 'heal':
+      user.heal(effect.amount);
+      break;
+    case 'xp':
+      user.addXp(effect.amount);
+      break;
+    case 'coins':
+      user.addCoins(effect.amount);
+      break;
+    default: {
+      const exhaustiveCheck: never = effect.type;
+      throw new Error(`Unhandled consumable effect: ${exhaustiveCheck}`);
+    }
+  }
+};
+
+export const useInventoryStore = create<InventoryState>((set, get) => ({
+  ...initialSnapshot,
+  addItem: (item, quantity = 1) => {
+    if (quantity <= 0) {
+      return;
+    }
+
+    set((state) => {
+      const existing = state.items[item.id];
+      const nextQuantity = (existing?.quantity ?? 0) + quantity;
+
+      return {
+        items: {
+          ...state.items,
+          [item.id]: {
+            item: existing?.item ?? item,
+            quantity: nextQuantity,
+          },
+        },
+      };
+    });
+  },
+  removeItem: (itemId, quantity = 1) => {
+    if (quantity <= 0) {
+      return;
+    }
+
+    set((state) => {
+      const existing = state.items[itemId];
+      if (!existing) {
+        return {} as Partial<InventoryState>;
+      }
+
+      const remaining = existing.quantity - quantity;
+      const updated = { ...state.items };
+
+      if (remaining > 0) {
+        updated[itemId] = {
+          ...existing,
+          quantity: remaining,
+        };
+      } else {
+        delete updated[itemId];
+      }
+
+      return { items: updated };
+    });
+  },
+  useItem: (itemId) => {
+    const entry = get().items[itemId];
+    if (!entry) {
+      return false;
+    }
+
+    if (entry.item.type === 'consumable') {
+      applyConsumableEffect(entry.item.effect);
+      set((state) => {
+        const updated = { ...state.items };
+        const remaining = entry.quantity - 1;
+
+        if (remaining > 0) {
+          updated[itemId] = {
+            ...entry,
+            quantity: remaining,
+          };
+        } else {
+          delete updated[itemId];
+        }
+
+        return { items: updated };
+      });
+      return true;
+    }
+
+    if (entry.item.type === 'equipment') {
+      useUserStore.getState().equip(entry.item.slot, entry.item.id);
+      return true;
+    }
+
+    return false;
+  },
+  equipItem: (itemId) => {
+    const entry = get().items[itemId];
+    if (!entry || entry.item.type !== 'equipment') {
+      return false;
+    }
+
+    useUserStore.getState().equip(entry.item.slot, entry.item.id);
+    return true;
+  },
+  unequip: (slot) => {
+    useUserStore.getState().unequip(slot);
+  },
+  hydrate: (snapshot) => {
+    set({
+      items: Object.fromEntries(
+        Object.entries(snapshot.items).map(([id, value]) => [
+          id,
+          {
+            item: value.item,
+            quantity: value.quantity,
+          },
+        ]),
+      ),
+    });
+  },
+  reset: () => {
+    set({ ...initialSnapshot });
+  },
+}));
+
+export const getInventorySnapshot = (state: InventoryState): InventorySnapshot => ({
+  items: Object.fromEntries(
+    Object.entries(state.items).map(([id, entry]) => [
+      id,
+      {
+        item: entry.item,
+        quantity: entry.quantity,
+      },
+    ]),
+  ),
+});
+
+export const inventoryInitialSnapshot = initialSnapshot;

--- a/src/lib/store/userStore.ts
+++ b/src/lib/store/userStore.ts
@@ -1,0 +1,152 @@
+import { create } from 'zustand';
+
+export type EquipmentSlot = 'head' | 'body' | 'weapon' | 'offhand' | 'accessory';
+
+export type EquipmentLoadout = Partial<Record<EquipmentSlot, string>>;
+
+export interface UserSnapshot {
+  level: number;
+  xp: number;
+  xpToNext: number;
+  hp: number;
+  maxHp: number;
+  coins: number;
+  equipment: EquipmentLoadout;
+}
+
+interface UserActions {
+  addXp: (amount: number) => void;
+  addCoins: (amount: number) => void;
+  spendCoins: (amount: number) => boolean;
+  takeDamage: (amount: number) => void;
+  heal: (amount: number) => void;
+  equip: (slot: EquipmentSlot, itemId: string) => void;
+  unequip: (slot: EquipmentSlot) => void;
+  hydrate: (snapshot: UserSnapshot) => void;
+  reset: () => void;
+}
+
+export type UserState = UserSnapshot & UserActions;
+
+const calculateXpToNext = (level: number) => Math.round(100 * Math.pow(1.15, level - 1));
+
+const initialSnapshot: UserSnapshot = {
+  level: 1,
+  xp: 0,
+  xpToNext: calculateXpToNext(1),
+  hp: 50,
+  maxHp: 50,
+  coins: 0,
+  equipment: {},
+};
+
+export const useUserStore = create<UserState>((set, get) => ({
+  ...initialSnapshot,
+  addXp: (amount: number) => {
+    if (amount <= 0) {
+      return;
+    }
+
+    set((state) => {
+      let { xp, level } = state;
+      let xpToNext = state.xpToNext;
+      let remainingXp = xp + amount;
+
+      while (remainingXp >= xpToNext) {
+        remainingXp -= xpToNext;
+        level += 1;
+        xpToNext = calculateXpToNext(level);
+      }
+
+      return {
+        xp: remainingXp,
+        level,
+        xpToNext,
+      };
+    });
+  },
+  addCoins: (amount: number) => {
+    if (amount === 0) {
+      return;
+    }
+
+    set((state) => ({
+      coins: Math.max(0, state.coins + amount),
+    }));
+  },
+  spendCoins: (amount: number) => {
+    if (amount <= 0) {
+      return true;
+    }
+
+    const { coins } = get();
+    if (coins < amount) {
+      return false;
+    }
+
+    set({ coins: coins - amount });
+    return true;
+  },
+  takeDamage: (amount: number) => {
+    if (amount <= 0) {
+      return;
+    }
+
+    set((state) => ({
+      hp: Math.max(0, state.hp - amount),
+    }));
+  },
+  heal: (amount: number) => {
+    if (amount <= 0) {
+      return;
+    }
+
+    set((state) => ({
+      hp: Math.min(state.maxHp, state.hp + amount),
+    }));
+  },
+  equip: (slot: EquipmentSlot, itemId: string) => {
+    set((state) => ({
+      equipment: {
+        ...state.equipment,
+        [slot]: itemId,
+      },
+    }));
+  },
+  unequip: (slot: EquipmentSlot) => {
+    set((state) => {
+      if (!(slot in state.equipment)) {
+        return {} as Partial<UserState>;
+      }
+
+      const updated = { ...state.equipment };
+      delete updated[slot];
+
+      return {
+        equipment: updated,
+      };
+    });
+  },
+  hydrate: (snapshot: UserSnapshot) => {
+    set({
+      ...snapshot,
+      xpToNext: snapshot.xpToNext ?? calculateXpToNext(snapshot.level),
+      equipment: { ...snapshot.equipment },
+    });
+  },
+  reset: () => {
+    set({ ...initialSnapshot });
+  },
+}));
+
+export const getUserSnapshot = (state: UserState): UserSnapshot => ({
+  level: state.level,
+  xp: state.xp,
+  xpToNext: state.xpToNext,
+  hp: state.hp,
+  maxHp: state.maxHp,
+  coins: state.coins,
+  equipment: { ...state.equipment },
+});
+
+export const userInitialSnapshot = initialSnapshot;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "strict": true,
     "paths": {
+      "@/lib/*": [
+        "./src/lib/*"
+      ],
       "@/*": [
         "./*"
       ]


### PR DESCRIPTION
## Summary
- add AsyncStorage and Zustand dependencies for state management and persistence
- implement typed Zustand stores for user stats, inventory, and item handling
- add AsyncStorage persistence helpers and hydrate stores during app bootstrap

## Testing
- npm run lint *(fails: missing newly added dependencies because registry access is restricted in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0dbd915988325b4b53f4b74a6f573