### PR TITLE
Add formulas module and custom TypeScript test harness

### DIFF
--- a/__tests__/formulas.test.ts
+++ b/__tests__/formulas.test.ts
@@ -1,0 +1,104 @@
+import {
+  TASK_VALUE_CEILING,
+  TASK_VALUE_FLOOR,
+  clampTaskValue,
+  getCriticalChance,
+  getCriticalMultiplier,
+  taskValueToBossDamage,
+  taskValueToDropRate,
+  taskValueToExperience,
+  taskValueToGold,
+  taskValueToTavernDamage,
+} from '../src/lib/formulas';
+
+describe('clampTaskValue', () => {
+  it('clamps values below the floor to the minimum supported task value', () => {
+    const clamped = clampTaskValue(TASK_VALUE_FLOOR - 100);
+
+    expect(clamped).toBe(TASK_VALUE_FLOOR);
+  });
+
+  it('clamps values above the ceiling to the maximum supported task value', () => {
+    const clamped = clampTaskValue(TASK_VALUE_CEILING + 100);
+
+    expect(clamped).toBe(TASK_VALUE_CEILING);
+  });
+
+  it('normalises non-finite input to zero', () => {
+    expect(clampTaskValue(Number.NaN)).toBe(0);
+    expect(clampTaskValue(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('critical calculations', () => {
+  it('keeps the base critical chance for non-positive strength values', () => {
+    expect(getCriticalChance(-50)).toBe(0.05);
+  });
+
+  it('scales the critical chance with strength until hitting the cap', () => {
+    expect(getCriticalChance(100)).toBeCloseTo(0.3, 3);
+    expect(getCriticalChance(500)).toBe(0.75);
+  });
+
+  it('returns a predictable multiplier with strength bonuses', () => {
+    expect(getCriticalMultiplier(0)).toBe(1.5);
+    expect(getCriticalMultiplier(80)).toBe(1.9);
+  });
+});
+
+describe('taskValueToTavernDamage', () => {
+  it('applies a minimum damage when the task value is neutral or positive', () => {
+    expect(taskValueToTavernDamage(0)).toBe(0.1);
+    expect(taskValueToTavernDamage(5)).toBe(0.1);
+  });
+
+  it('returns scaled damage when the task value is negative', () => {
+    expect(taskValueToTavernDamage(-4)).toBe(1);
+    expect(taskValueToTavernDamage(-100)).toBeCloseTo(11.82, 2);
+  });
+});
+
+describe('taskValueToBossDamage', () => {
+  it('never awards negative boss damage', () => {
+    expect(taskValueToBossDamage(-5, 10)).toBe(0);
+    expect(taskValueToBossDamage(5, 10, 5000)).toBe(0);
+  });
+
+  it('scales with strength and defence mitigation', () => {
+    expect(taskValueToBossDamage(10, 50)).toBeCloseTo(12.5, 2);
+    expect(taskValueToBossDamage(10, 50, 100)).toBeCloseTo(11.5, 2);
+  });
+});
+
+describe('taskValueToExperience', () => {
+  it('returns zero for non-positive task values', () => {
+    expect(taskValueToExperience(-10, 25)).toBe(0);
+  });
+
+  it('calculates experience rewards with attribute and critical modifiers', () => {
+    expect(taskValueToExperience(10, 50)).toBeCloseTo(9, 2);
+    expect(taskValueToExperience(10, 50, { isCritical: true })).toBeCloseTo(15.75, 2);
+  });
+});
+
+describe('taskValueToGold', () => {
+  it('returns zero gold for depleted task values', () => {
+    expect(taskValueToGold(0, 40)).toBe(0);
+  });
+
+  it('calculates gold rewards with perception bonuses and critical hits', () => {
+    expect(taskValueToGold(10, 40)).toBeCloseTo(5.6, 2);
+    expect(taskValueToGold(10, 40, { isCritical: true })).toBeCloseTo(9.52, 2);
+  });
+});
+
+describe('taskValueToDropRate', () => {
+  it('starts with the base drop chance when perception and task value are zero', () => {
+    expect(taskValueToDropRate(0, 0)).toBe(0.3);
+  });
+
+  it('increases drop chance with task value and perception until capped', () => {
+    expect(taskValueToDropRate(5, 10)).toBeCloseTo(0.433, 3);
+    expect(taskValueToDropRate(100, 500)).toBe(0.9);
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  testMatch: ['**/?(*.)+(test).ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "node scripts/run-tests.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
@@ -39,9 +40,11 @@
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
-    "typescript": "~5.9.2",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~10.0.0"
+    "eslint-config-expo": "~10.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.4",
+    "typescript": "~5.9.2"
   },
   "private": true
 }

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+const ts = require('typescript');
+const assert = require('assert');
+
+const ROOT = path.resolve(__dirname, '..');
+const TEST_DIR = path.join(ROOT, '__tests__');
+
+const compilerOptions = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2019,
+  esModuleInterop: true,
+  jsx: ts.JsxEmit.React,
+};
+
+function registerTypeScriptLoader() {
+  const load = (module, filename) => {
+    const source = fs.readFileSync(filename, 'utf8');
+    const result = ts.transpileModule(source, {
+      compilerOptions,
+      fileName: filename,
+    });
+    module._compile(result.outputText, filename);
+  };
+
+  require.extensions['.ts'] = load;
+  require.extensions['.tsx'] = load;
+}
+
+registerTypeScriptLoader();
+
+function findTestFiles(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findTestFiles(entryPath));
+    } else if (/\.test\.ts$/.test(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+function createSuite(name) {
+  return {
+    name,
+    suites: [],
+    tests: [],
+    beforeEach: [],
+    afterEach: [],
+  };
+}
+
+function createExpect(actual) {
+  const matchers = {
+    toBe(expected) {
+      assert.strictEqual(actual, expected);
+    },
+    toEqual(expected) {
+      assert.deepStrictEqual(actual, expected);
+    },
+    toBeCloseTo(expected, precision = 2) {
+      if (typeof actual !== 'number' || typeof expected !== 'number') {
+        throw new Error('toBeCloseTo matcher requires numeric values');
+      }
+      const diff = Math.abs(actual - expected);
+      const tolerance = Math.pow(10, -precision) / 2;
+      assert.ok(
+        diff <= tolerance,
+        `Expected ${actual} to be within ${tolerance} of ${expected} (precision ${precision})`,
+      );
+    },
+    toBeGreaterThan(expected) {
+      assert.ok(actual > expected, `Expected ${actual} to be greater than ${expected}`);
+    },
+    toBeGreaterThanOrEqual(expected) {
+      assert.ok(actual >= expected, `Expected ${actual} to be greater than or equal to ${expected}`);
+    },
+    toBeLessThan(expected) {
+      assert.ok(actual < expected, `Expected ${actual} to be less than ${expected}`);
+    },
+    toBeLessThanOrEqual(expected) {
+      assert.ok(actual <= expected, `Expected ${actual} to be less than or equal to ${expected}`);
+    },
+    toBeDefined() {
+      assert.notStrictEqual(actual, undefined, 'Expected value to be defined');
+    },
+    toBeUndefined() {
+      assert.strictEqual(actual, undefined, 'Expected value to be undefined');
+    },
+    toThrow(expectedMessage) {
+      if (typeof actual !== 'function') {
+        throw new Error('toThrow matcher requires a function');
+      }
+      let threw = false;
+      try {
+        actual();
+      } catch (error) {
+        threw = true;
+        if (expectedMessage !== undefined) {
+          const message = error && error.message ? error.message : String(error);
+          if (expectedMessage instanceof RegExp) {
+            assert.ok(
+              expectedMessage.test(message),
+              `Expected error message ${message} to match ${expectedMessage}`,
+            );
+          } else {
+            assert.strictEqual(message, expectedMessage);
+          }
+        }
+      }
+      if (!threw) {
+        throw new Error('Expected function to throw an error');
+      }
+    },
+  };
+
+  matchers.not = {
+    toBe(expected) {
+      assert.notStrictEqual(actual, expected);
+    },
+    toEqual(expected) {
+      try {
+        assert.deepStrictEqual(actual, expected);
+      } catch (error) {
+        return;
+      }
+      throw new Error('Expected values to be different');
+    },
+  };
+
+  return matchers;
+}
+
+function setupGlobals(filePath) {
+  const original = {
+    describe: global.describe,
+    it: global.it,
+    test: global.test,
+    beforeEach: global.beforeEach,
+    afterEach: global.afterEach,
+    expect: global.expect,
+  };
+
+  const rootSuite = createSuite(path.relative(ROOT, filePath));
+  const stack = [rootSuite];
+
+  const getCurrentSuite = () => stack[stack.length - 1];
+
+  global.describe = (name, fn) => {
+    const suite = createSuite(name);
+    getCurrentSuite().suites.push(suite);
+    stack.push(suite);
+    try {
+      fn();
+    } finally {
+      stack.pop();
+    }
+  };
+
+  const registerTest = (name, fn) => {
+    getCurrentSuite().tests.push({ name, fn });
+  };
+
+  global.it = global.test = (name, fn) => {
+    registerTest(name, fn);
+  };
+
+  global.beforeEach = (fn) => {
+    getCurrentSuite().beforeEach.push(fn);
+  };
+
+  global.afterEach = (fn) => {
+    getCurrentSuite().afterEach.push(fn);
+  };
+
+  global.expect = (value) => createExpect(value);
+
+  return { original, rootSuite };
+}
+
+function restoreGlobals(original) {
+  Object.assign(global, original);
+}
+
+async function executeSuite(suite, ancestors = []) {
+  let passed = 0;
+  let failed = 0;
+  const suitePath = ancestors.map((ancestor) => ancestor.name).filter(Boolean);
+  const currentPath = suite.name ? suitePath.concat(suite.name) : suitePath;
+
+  for (const childSuite of suite.suites) {
+    const result = await executeSuite(childSuite, ancestors.concat(suite));
+    passed += result.passed;
+    failed += result.failed;
+  }
+
+  const beforeHooks = ancestors.concat(suite);
+  const afterHooks = beforeHooks.slice().reverse();
+
+  for (const test of suite.tests) {
+    const fullName = currentPath.concat(test.name).filter(Boolean).join(' › ');
+    const runHooks = async (hooks) => {
+      for (const suiteHooks of hooks) {
+        for (const hook of suiteHooks.beforeEach) {
+          await hook();
+        }
+      }
+    };
+
+    const runAfterHooks = async () => {
+      for (const suiteHooks of afterHooks) {
+        for (const hook of suiteHooks.afterEach) {
+          await hook();
+        }
+      }
+    };
+
+    try {
+      await runHooks(beforeHooks);
+      await Promise.resolve().then(() => test.fn());
+      await runAfterHooks();
+      console.log(`✓ ${fullName}`);
+      passed += 1;
+    } catch (error) {
+      failed += 1;
+      console.error(`✗ ${fullName}`);
+      if (error && error.stack) {
+        console.error(error.stack);
+      } else {
+        console.error(error);
+      }
+      try {
+        await runAfterHooks();
+      } catch (hookError) {
+        console.error('Error in afterEach hook:', hookError);
+      }
+    }
+  }
+
+  return { passed, failed };
+}
+
+async function runTestFile(filePath) {
+  const { original, rootSuite } = setupGlobals(filePath);
+  let compiled;
+
+  try {
+    const source = fs.readFileSync(filePath, 'utf8');
+    const result = ts.transpileModule(source, {
+      compilerOptions,
+      fileName: filePath,
+    });
+    compiled = result.outputText;
+  } catch (error) {
+    restoreGlobals(original);
+    throw error;
+  }
+
+  try {
+    const testModule = new Module(filePath, module);
+    testModule.filename = filePath;
+    testModule.paths = Module._nodeModulePaths(path.dirname(filePath));
+    const originalRequire = testModule.require.bind(testModule);
+    testModule.require = (request) => {
+      if (request.startsWith('@/')) {
+        const resolvedPath = path.join(ROOT, request.slice(2));
+        return originalRequire(resolvedPath);
+      }
+      return originalRequire(request);
+    };
+    testModule._compile(compiled, filePath);
+    const result = await executeSuite(rootSuite);
+    restoreGlobals(original);
+    return result;
+  } catch (error) {
+    restoreGlobals(original);
+    throw error;
+  }
+}
+
+async function main() {
+  const testFiles = findTestFiles(TEST_DIR);
+  if (testFiles.length === 0) {
+    console.log('No test files found.');
+    return;
+  }
+
+  let totalPassed = 0;
+  let totalFailed = 0;
+
+  for (const filePath of testFiles) {
+    const relativePath = path.relative(ROOT, filePath);
+    console.log(`\nRunning ${relativePath}`);
+    try {
+      const result = await runTestFile(filePath);
+      totalPassed += result.passed;
+      totalFailed += result.failed;
+      if (result.failed === 0) {
+        console.log(`PASS ${relativePath}`);
+      } else {
+        console.log(`FAIL ${relativePath}`);
+      }
+    } catch (error) {
+      totalFailed += 1;
+      console.error(`Error executing ${relativePath}`);
+      console.error(error && error.stack ? error.stack : error);
+    }
+  }
+
+  console.log(`\nTest summary: ${totalPassed} passed, ${totalFailed} failed`);
+  if (totalFailed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('Unexpected error while running tests');
+  console.error(error && error.stack ? error.stack : error);
+  process.exitCode = 1;
+});

--- a/src/lib/formulas.ts
+++ b/src/lib/formulas.ts
@@ -1,0 +1,134 @@
+export const TASK_VALUE_FLOOR = -47.27;
+export const TASK_VALUE_CEILING = 21.27;
+
+const MIN_TAVERN_DAMAGE = 0.1;
+const BASE_CRITICAL_CHANCE = 0.05;
+const MAX_CRITICAL_CHANCE = 0.75;
+const BASE_CRITICAL_MULTIPLIER = 1.5;
+const STAT_CRITICAL_DIVISOR = 200;
+const DROP_BASE_CHANCE = 0.3;
+const DROP_VALUE_DIVISOR = 60;
+const DROP_PERCEPTION_DIVISOR = 200;
+
+function toFinite(value: number): number {
+  if (!Number.isFinite(value) || Number.isNaN(value)) {
+    return 0;
+  }
+
+  return value;
+}
+
+export function clampTaskValue(value: number): number {
+  const finite = toFinite(value);
+
+  if (finite < TASK_VALUE_FLOOR) {
+    return TASK_VALUE_FLOOR;
+  }
+
+  if (finite > TASK_VALUE_CEILING) {
+    return TASK_VALUE_CEILING;
+  }
+
+  return finite;
+}
+
+export function getCriticalChance(strength: number): number {
+  const safeStrength = Math.max(0, toFinite(strength));
+  const chance = BASE_CRITICAL_CHANCE + safeStrength / (STAT_CRITICAL_DIVISOR * 2);
+
+  return Math.min(MAX_CRITICAL_CHANCE, Number(chance.toFixed(3)));
+}
+
+export function getCriticalMultiplier(strength: number): number {
+  const safeStrength = Math.max(0, toFinite(strength));
+  const multiplier = BASE_CRITICAL_MULTIPLIER + safeStrength / STAT_CRITICAL_DIVISOR;
+
+  return Number(multiplier.toFixed(2));
+}
+
+export function taskValueToTavernDamage(taskValue: number): number {
+  const clamped = clampTaskValue(taskValue);
+
+  if (clamped >= 0) {
+    return MIN_TAVERN_DAMAGE;
+  }
+
+  const damage = Math.max(MIN_TAVERN_DAMAGE, -clamped * 0.25);
+  return Number(damage.toFixed(2));
+}
+
+export function taskValueToBossDamage(
+  taskValue: number,
+  strength: number,
+  bossDefense = 0,
+): number {
+  const clamped = Math.max(0, clampTaskValue(taskValue));
+  if (clamped === 0) {
+    return 0;
+  }
+
+  const safeStrength = Math.max(0, toFinite(strength));
+  const attackMultiplier = 1 + safeStrength / STAT_CRITICAL_DIVISOR;
+  const baseDamage = clamped * attackMultiplier;
+  const mitigated = baseDamage - Math.max(0, toFinite(bossDefense)) / 100;
+
+  return Number(Math.max(0, mitigated).toFixed(2));
+}
+
+interface RewardOptions {
+  isCritical?: boolean;
+  baseMultiplier?: number;
+}
+
+function taskValueToReward(
+  taskValue: number,
+  attribute: number,
+  { isCritical = false, baseMultiplier = 1 }: RewardOptions = {},
+): number {
+  const clamped = Math.max(0, clampTaskValue(taskValue));
+  if (clamped === 0) {
+    return 0;
+  }
+
+  const safeAttribute = Math.max(0, toFinite(attribute));
+  const attributeMultiplier = 1 + safeAttribute / 100;
+  let reward = clamped * baseMultiplier * attributeMultiplier;
+
+  if (isCritical) {
+    reward *= getCriticalMultiplier(safeAttribute);
+  }
+
+  return Number(reward.toFixed(2));
+}
+
+export function taskValueToExperience(
+  taskValue: number,
+  intelligence: number,
+  options?: RewardOptions,
+): number {
+  return taskValueToReward(taskValue, intelligence, {
+    baseMultiplier: 0.6,
+    ...options,
+  });
+}
+
+export function taskValueToGold(
+  taskValue: number,
+  perception: number,
+  options?: RewardOptions,
+): number {
+  return taskValueToReward(taskValue, perception, {
+    baseMultiplier: 0.4,
+    ...options,
+  });
+}
+
+export function taskValueToDropRate(taskValue: number, perception: number): number {
+  const clamped = Math.max(0, clampTaskValue(taskValue));
+  const safePerception = Math.max(0, toFinite(perception));
+
+  const chance =
+    DROP_BASE_CHANCE + clamped / DROP_VALUE_DIVISOR + safePerception / DROP_PERCEPTION_DIVISOR;
+
+  return Number(Math.min(0.9, chance).toFixed(3));
+}


### PR DESCRIPTION
## Summary
- add a formulas utility module with clamping, critical hit, reward, and drop-rate calculations
- configure Jest metadata and wire npm test to a TypeScript-aware runner that executes test suites without external downloads
- add boundary-focused tests for all formulas to guarantee expected behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0dbe8af08832594a63abfcb6210cc