### PR TITLE
Add dashboard UI components

### DIFF
--- a/src/components/CurrencyPill.tsx
+++ b/src/components/CurrencyPill.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+type CurrencyPillProps = {
+  label: string;
+  value: number;
+};
+
+const CurrencyPill: React.FC<CurrencyPillProps> = ({ label, value }) => {
+  const displayValue = Number.isInteger(value) ? value.toString() : value.toFixed(1);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.value}>{displayValue}</Text>
+      <Text style={styles.label}>{label}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#d2d6dc',
+    backgroundColor: '#f8fafc',
+  },
+  value: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1f2933',
+    marginRight: 6,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: '#6b7280',
+    textTransform: 'uppercase',
+  },
+});
+
+export default CurrencyPill;

--- a/src/components/HabitListItem.tsx
+++ b/src/components/HabitListItem.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+type HabitListItemProps = {
+  title: string;
+  reward: string;
+  status: 'completed' | 'startable';
+  onStart?: () => void;
+};
+
+const HabitListItem: React.FC<HabitListItemProps> = ({ title, reward, status, onStart }) => {
+  const isCompleted = status === 'completed';
+
+  return (
+    <View style={[styles.container, isCompleted && styles.completedContainer]}>
+      <View style={styles.infoContainer}>
+        {isCompleted ? <Text style={styles.checkMark}>✅</Text> : null}
+        <View style={styles.textContainer}>
+          <Text style={[styles.title, isCompleted && styles.completedText]}>{title}</Text>
+          <Text style={[styles.reward, isCompleted && styles.completedReward]}>{reward}</Text>
+        </View>
+      </View>
+      {status === 'startable' ? (
+        <TouchableOpacity
+          style={styles.startButton}
+          onPress={onStart}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.startButtonText}>Start</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: '#ffffff',
+    shadowColor: '#000000',
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 1,
+    marginBottom: 12,
+  },
+  completedContainer: {
+    backgroundColor: '#f3f4f6',
+  },
+  infoContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  checkMark: {
+    fontSize: 18,
+    marginRight: 12,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1f2933',
+  },
+  completedText: {
+    color: '#6b7280',
+    textDecorationLine: 'line-through',
+  },
+  reward: {
+    marginTop: 4,
+    fontSize: 13,
+    color: '#6b7280',
+  },
+  completedReward: {
+    color: '#9ca3af',
+  },
+  startButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: '#4f46e5',
+  },
+  startButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+});
+
+export default HabitListItem;

--- a/src/components/StatBar.tsx
+++ b/src/components/StatBar.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+type StatBarProps = {
+  label: string;
+  value: number;
+  max: number;
+  color: string;
+};
+
+const formatNumber = (num: number) => {
+  return Number.isInteger(num) ? num.toString() : num.toFixed(1);
+};
+
+const StatBar: React.FC<StatBarProps> = ({ label, value, max, color }) => {
+  const clampedMax = Math.max(max, 1);
+  const clampedValue = Math.min(Math.max(value, 0), clampedMax);
+  const progress = clampedValue / clampedMax;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.label}>{label}</Text>
+        <Text style={styles.value}>
+          {formatNumber(clampedValue)}/{formatNumber(clampedMax)}
+        </Text>
+      </View>
+      <View style={styles.barBackground}>
+        <View style={[styles.barFill, { width: `${progress * 100}%`, backgroundColor: color }]} />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1f2933',
+  },
+  value: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#52606d',
+  },
+  barBackground: {
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: '#e4e7eb',
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    borderRadius: 6,
+  },
+});
+
+export default StatBar;


### PR DESCRIPTION
## Summary
- add a stat bar component with progress fill styling
- add a currency pill component for labeled totals
- add a habit list item that supports completed and startable states

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e106f778708325900d3116c5c99282