### PR TITLE
Create dark themed home dashboard

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,42 +1,191 @@
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native';
 
-import InventoryScreen from './src/screens/InventoryScreen';
-import ProfileScreen from './src/screens/ProfileScreen';
-import QuestsScreen from './src/screens/QuestsScreen';
-import ShopScreen from './src/screens/ShopScreen';
-import TasksScreen from './src/screens/TasksScreen';
+import CurrencyPill from './src/components/CurrencyPill';
+import HabitListItem from './src/components/HabitListItem';
+import StatBar from './src/components/StatBar';
 
-type RootTabParamList = {
-  Tasks: undefined;
-  Quests: undefined;
-  Shop: undefined;
-  Inventory: undefined;
-  Profile: undefined;
-};
+const level = 12;
+const hp = 85;
+const hpMax = 100;
+const xp = 750;
+const xpMax = 1000;
+const gold = 2450;
+const gems = 15;
 
-const Tab = createBottomTabNavigator<RootTabParamList>();
+const starterGoals = [
+  {
+    id: '1',
+    title: 'Begin your journey',
+    reward: 'Reward: 10 gold',
+    status: 'completed' as const,
+  },
+  {
+    id: '2',
+    title: 'Create your first habit',
+    reward: 'Reward: 5 gold',
+    status: 'startable' as const,
+  },
+  {
+    id: '3',
+    title: 'Complete dailies for 3 days',
+    reward: 'Reward: 25 XP',
+    status: 'startable' as const,
+  },
+];
 
 const App: React.FC = () => {
+  const handleStartGoal = (title: string) => () => {
+    console.log(`Start goal: ${title}`);
+  };
+
   return (
-    <NavigationContainer>
-      <Tab.Navigator
-        screenOptions={{
-          headerShown: false,
-          tabBarLabelStyle: {
-            fontSize: 12,
-          },
-        }}
-      >
-        <Tab.Screen name="Tasks" component={TasksScreen} />
-        <Tab.Screen name="Quests" component={QuestsScreen} />
-        <Tab.Screen name="Shop" component={ShopScreen} />
-        <Tab.Screen name="Inventory" component={InventoryScreen} />
-        <Tab.Screen name="Profile" component={ProfileScreen} />
-      </Tab.Navigator>
-    </NavigationContainer>
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="light-content" />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.headerRow}>
+          <View style={styles.headerPlaceholder} />
+          <Text style={styles.headerGreeting}>Welcome, Adventurer!</Text>
+          <Text style={styles.levelText}>Lvl {level}</Text>
+        </View>
+
+        <View style={styles.sectionSpacing}>
+          <View style={styles.playerCard}>
+            <View style={styles.avatarContainer}>
+              <Text style={styles.avatarInitials}>HA</Text>
+            </View>
+            <View style={styles.playerStats}>
+              <View style={styles.statBarWrapper}>
+                <StatBar label="Health" value={hp} max={hpMax} color="#22C55E" />
+              </View>
+              <View style={styles.statBarWrapper}>
+                <StatBar label="Experience" value={xp} max={xpMax} color="#A78BFA" />
+              </View>
+              <View style={styles.currencyRow}>
+                <View style={styles.currencyPillWrapper}>
+                  <CurrencyPill label="Gold" value={gold} />
+                </View>
+                <CurrencyPill label="Gems" value={gems} />
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.sectionSpacing}>
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Starter Goals</Text>
+            <View>
+              {starterGoals.map(goal => (
+                <View key={goal.id} style={styles.goalItemWrapper}>
+                  <HabitListItem
+                    title={goal.title}
+                    reward={goal.reward}
+                    status={goal.status}
+                    onStart={goal.status === 'startable' ? handleStartGoal(goal.title) : undefined}
+                  />
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 };
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#0F172A',
+  },
+  scrollContent: {
+    padding: 24,
+    paddingBottom: 32,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 24,
+  },
+  headerPlaceholder: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#1F2937',
+    backgroundColor: '#111827',
+  },
+  headerGreeting: {
+    flex: 1,
+    marginHorizontal: 12,
+    textAlign: 'center',
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#E5E7EB',
+  },
+  levelText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#E5E7EB',
+  },
+  sectionSpacing: {
+    marginBottom: 24,
+  },
+  playerCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 20,
+    borderRadius: 20,
+    backgroundColor: '#111827',
+    borderWidth: 1,
+    borderColor: '#1F2937',
+  },
+  avatarContainer: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    borderWidth: 2,
+    borderColor: '#1F2937',
+    backgroundColor: '#1E293B',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 20,
+  },
+  avatarInitials: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#E5E7EB',
+  },
+  playerStats: {
+    flex: 1,
+  },
+  statBarWrapper: {
+    marginBottom: 12,
+  },
+  currencyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  currencyPillWrapper: {
+    marginRight: 12,
+  },
+  sectionCard: {
+    padding: 20,
+    borderRadius: 20,
+    backgroundColor: '#111827',
+    borderWidth: 1,
+    borderColor: '#1F2937',
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#E5E7EB',
+    marginBottom: 16,
+  },
+  goalItemWrapper: {
+    marginBottom: 12,
+  },
+});
 
 export default App;


### PR DESCRIPTION
## Summary
- replace the navigation shell with a home dashboard layout that matches the dark UI mock
- add a player card with avatar placeholder, stat bars, and currency pills using existing components
- introduce a starter goals section that wires HabitListItem actions to console logging

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e14ccfd7dc83259bc12728da1851ca