### PR TITLE
Add reusable auth UI components

### DIFF
--- a/src/components/AuthCard.tsx
+++ b/src/components/AuthCard.tsx
@@ -1,0 +1,37 @@
+import React, { ReactNode } from 'react';
+import { View, StyleSheet } from 'react-native';
+
+const colors = {
+  bg: '#0F172A',
+  card: '#111827',
+  border: '#1F2937',
+  text: '#E5E7EB',
+  muted: '#9CA3AF',
+  primary: '#2563EB',
+  primaryText: '#FFFFFF',
+};
+
+interface AuthCardProps {
+  children: ReactNode;
+}
+
+const AuthCard: React.FC<AuthCardProps> = ({ children }) => {
+  return <View style={styles.container}>{children}</View>;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.card,
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.25,
+    shadowRadius: 16,
+    elevation: 8,
+    width: '90%',
+    alignSelf: 'center',
+  },
+});
+
+export default AuthCard;

--- a/src/components/LabeledField.tsx
+++ b/src/components/LabeledField.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Text, TextInput, View, StyleSheet, KeyboardTypeOptions } from 'react-native';
+
+const colors = {
+  bg: '#0F172A',
+  card: '#111827',
+  border: '#1F2937',
+  text: '#E5E7EB',
+  muted: '#9CA3AF',
+  primary: '#2563EB',
+  primaryText: '#FFFFFF',
+};
+
+interface LabeledFieldProps {
+  label: string;
+  placeholder?: string;
+  value: string;
+  onChangeText: (text: string) => void;
+  keyboardType?: KeyboardTypeOptions;
+}
+
+const LabeledField: React.FC<LabeledFieldProps> = ({
+  label,
+  placeholder,
+  value,
+  onChangeText,
+  keyboardType,
+}) => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>{label}</Text>
+      <TextInput
+        style={styles.input}
+        placeholder={placeholder}
+        placeholderTextColor={colors.muted}
+        value={value}
+        onChangeText={onChangeText}
+        keyboardType={keyboardType}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  label: {
+    color: colors.text,
+    fontSize: 14,
+    marginBottom: 8,
+    fontWeight: '500',
+  },
+  input: {
+    backgroundColor: colors.bg,
+    color: colors.text,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+});
+
+export default LabeledField;

--- a/src/components/OrDivider.tsx
+++ b/src/components/OrDivider.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const colors = {
+  bg: '#0F172A',
+  card: '#111827',
+  border: '#1F2937',
+  text: '#E5E7EB',
+  muted: '#9CA3AF',
+  primary: '#2563EB',
+  primaryText: '#FFFFFF',
+};
+
+const OrDivider: React.FC = () => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.line} />
+      <Text style={styles.text}>or</Text>
+      <View style={styles.line} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 24,
+  },
+  line: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.border,
+  },
+  text: {
+    color: colors.muted,
+    marginHorizontal: 12,
+    fontSize: 14,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+});
+
+export default OrDivider;

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { Text, TextInput, View, StyleSheet, Pressable } from 'react-native';
+
+const colors = {
+  bg: '#0F172A',
+  card: '#111827',
+  border: '#1F2937',
+  text: '#E5E7EB',
+  muted: '#9CA3AF',
+  primary: '#2563EB',
+  primaryText: '#FFFFFF',
+};
+
+interface PasswordFieldProps {
+  label: string;
+  placeholder?: string;
+  value: string;
+  onChangeText: (text: string) => void;
+}
+
+const PasswordField: React.FC<PasswordFieldProps> = ({
+  label,
+  placeholder,
+  value,
+  onChangeText,
+}) => {
+  const [secure, setSecure] = useState(true);
+
+  const toggleSecure = () => setSecure((prev) => !prev);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.inputWrapper}>
+        <TextInput
+          style={styles.input}
+          placeholder={placeholder}
+          placeholderTextColor={colors.muted}
+          value={value}
+          onChangeText={onChangeText}
+          secureTextEntry={secure}
+        />
+        <Pressable onPress={toggleSecure} style={styles.toggleButton}>
+          <Text style={styles.toggleText}>{secure ? 'Show' : 'Hide'}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  label: {
+    color: colors.text,
+    fontSize: 14,
+    marginBottom: 8,
+    fontWeight: '500',
+  },
+  inputWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.bg,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingLeft: 16,
+  },
+  input: {
+    flex: 1,
+    color: colors.text,
+    fontSize: 16,
+    paddingVertical: 12,
+    paddingRight: 8,
+  },
+  toggleButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  toggleText: {
+    color: colors.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});
+
+export default PasswordField;

--- a/src/components/SocialButton.tsx
+++ b/src/components/SocialButton.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+
+const colors = {
+  bg: '#0F172A',
+  card: '#111827',
+  border: '#1F2937',
+  text: '#E5E7EB',
+  muted: '#9CA3AF',
+  primary: '#2563EB',
+  primaryText: '#FFFFFF',
+};
+
+interface SocialButtonProps {
+  text: string;
+  onPress?: () => void;
+  variant?: 'default' | 'primary';
+}
+
+const SocialButton: React.FC<SocialButtonProps> = ({ text, onPress, variant = 'default' }) => {
+  const isPrimary = variant === 'primary';
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.button,
+        isPrimary ? styles.primaryButton : styles.defaultButton,
+        pressed && styles.pressed,
+      ]}
+    >
+      <Text style={[styles.text, isPrimary ? styles.primaryText : styles.defaultText]}>{text}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    width: '100%',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 8,
+  },
+  defaultButton: {
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  primaryButton: {
+    backgroundColor: colors.primary,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  defaultText: {
+    color: colors.text,
+  },
+  primaryText: {
+    color: colors.primaryText,
+  },
+});
+
+export default SocialButton;


### PR DESCRIPTION
## Summary
- add AuthCard container for consistent authentication layout styling
- add labeled and password field inputs with dark theme styling
- create divider and social button components for authentication flows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1528ed938832588cdc6a6966dc5d9