### PR TITLE
Add Home-first tab navigation with placeholder task screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,17 +2,15 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
-import InventoryScreen from './src/screens/InventoryScreen';
+import DailiesScreen from './src/screens/DailiesScreen';
+import HomeScreen from './src/screens/HomeScreen';
 import ProfileScreen from './src/screens/ProfileScreen';
-import QuestsScreen from './src/screens/QuestsScreen';
-import ShopScreen from './src/screens/ShopScreen';
-import TasksScreen from './src/screens/TasksScreen';
+import ToDosScreen from './src/screens/ToDosScreen';
 
 type RootTabParamList = {
-  Tasks: undefined;
-  Quests: undefined;
-  Shop: undefined;
-  Inventory: undefined;
+  Home: undefined;
+  Dailies: undefined;
+  ToDos: undefined;
   Profile: undefined;
 };
 
@@ -22,6 +20,7 @@ const App: React.FC = () => {
   return (
     <NavigationContainer>
       <Tab.Navigator
+        initialRouteName="Home"
         screenOptions={{
           headerShown: false,
           tabBarLabelStyle: {
@@ -29,10 +28,16 @@ const App: React.FC = () => {
           },
         }}
       >
-        <Tab.Screen name="Tasks" component={TasksScreen} />
-        <Tab.Screen name="Quests" component={QuestsScreen} />
-        <Tab.Screen name="Shop" component={ShopScreen} />
-        <Tab.Screen name="Inventory" component={InventoryScreen} />
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="Dailies" component={DailiesScreen} />
+        <Tab.Screen
+          name="ToDos"
+          component={ToDosScreen}
+          options={{
+            title: 'To-Dos',
+            tabBarLabel: 'To-Dos',
+          }}
+        />
         <Tab.Screen name="Profile" component={ProfileScreen} />
       </Tab.Navigator>
     </NavigationContainer>

--- a/src/screens/DailiesScreen.tsx
+++ b/src/screens/DailiesScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+
+const DailiesScreen: React.FC = () => {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <Text style={styles.title}>Dailies</Text>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#0F172A',
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#E5E7EB',
+  },
+});
+
+export default DailiesScreen;

--- a/src/screens/ToDosScreen.tsx
+++ b/src/screens/ToDosScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+
+const ToDosScreen: React.FC = () => {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <Text style={styles.title}>To-Dos</Text>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#0F172A',
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#E5E7EB',
+  },
+});
+
+export default ToDosScreen;


### PR DESCRIPTION
## Summary
- update the bottom tab navigator to use Home as the initial route alongside Dailies, To-Dos, and Profile tabs
- add simple placeholder screens for the Dailies and To-Dos tabs so the layout renders centered titles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1537bae1083258eb583ba8b76f43c