### PR TITLE
Adjust header spacing on home screen

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -98,6 +98,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    marginTop: 16,
     marginBottom: 24,
   },
   headerLeft: {


### PR DESCRIPTION
## Summary
- add top margin to the home screen header row so it sits lower on the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15685e42c83259cd2deb9dbe53eee