### PR TITLE
feat: centralize color palette

### DIFF
--- a/src/components/CurrencyPill.tsx
+++ b/src/components/CurrencyPill.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { colors } from '../theme/colors';
+
 type CurrencyPillProps = {
   label: string;
   value: number;
@@ -25,19 +27,19 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: '#d2d6dc',
-    backgroundColor: '#f8fafc',
+    borderColor: colors.border,
+    backgroundColor: colors.card,
   },
   value: {
     fontSize: 18,
     fontWeight: '700',
-    color: '#1f2933',
+    color: colors.text,
     marginRight: 6,
   },
   label: {
     fontSize: 12,
     fontWeight: '500',
-    color: '#6b7280',
+    color: colors.muted,
     textTransform: 'uppercase',
   },
 });

--- a/src/components/HabitListItem.tsx
+++ b/src/components/HabitListItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
+import { colors } from '../theme/colors';
+
 type HabitListItemProps = {
   title: string;
   reward: string;
@@ -40,8 +42,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     borderRadius: 12,
-    backgroundColor: '#ffffff',
-    shadowColor: '#000000',
+    backgroundColor: colors.card,
+    shadowColor: colors.bg,
     shadowOpacity: 0.05,
     shadowRadius: 4,
     shadowOffset: { width: 0, height: 2 },
@@ -49,7 +51,7 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   completedContainer: {
-    backgroundColor: '#f3f4f6',
+    backgroundColor: colors.border,
   },
   infoContainer: {
     flexDirection: 'row',
@@ -66,28 +68,28 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#1f2933',
+    color: colors.text,
   },
   completedText: {
-    color: '#6b7280',
+    color: colors.muted,
     textDecorationLine: 'line-through',
   },
   reward: {
     marginTop: 4,
     fontSize: 13,
-    color: '#6b7280',
+    color: colors.muted,
   },
   completedReward: {
-    color: '#9ca3af',
+    color: colors.muted,
   },
   startButton: {
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 20,
-    backgroundColor: '#4f46e5',
+    backgroundColor: colors.button,
   },
   startButtonText: {
-    color: '#ffffff',
+    color: colors.buttonText,
     fontWeight: '600',
     fontSize: 14,
   },

--- a/src/components/StatBar.tsx
+++ b/src/components/StatBar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { colors } from '../theme/colors';
+
 type StatBarProps = {
   label: string;
   value: number;
@@ -45,17 +47,17 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#1f2933',
+    color: colors.text,
   },
   value: {
     fontSize: 14,
     fontWeight: '500',
-    color: '#52606d',
+    color: colors.muted,
   },
   barBackground: {
     height: 12,
     borderRadius: 6,
-    backgroundColor: '#e4e7eb',
+    backgroundColor: colors.border,
     overflow: 'hidden',
   },
   barFill: {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -10,6 +10,7 @@ import {
 import CurrencyPill from '../components/CurrencyPill';
 import HabitListItem from '../components/HabitListItem';
 import StatBar from '../components/StatBar';
+import { colors } from '../theme/colors';
 
 const level = 12;
 const hp = 85;
@@ -39,9 +40,9 @@ const HomeScreen: React.FC = () => {
               </View>
             </View>
             <View style={styles.statsSection}>
-              <StatBar label="Health" value={hp} max={hpMax} color="#22C55E" />
+              <StatBar label="Health" value={hp} max={hpMax} color={colors.green} />
               <View style={styles.barSpacing} />
-              <StatBar label="Experience" value={xp} max={xpMax} color="#A78BFA" />
+              <StatBar label="Experience" value={xp} max={xpMax} color={colors.purple} />
               <View style={styles.currencyRow}>
                 <View style={styles.currencyItem}>
                   <CurrencyPill label="Gold" value={gold} />
@@ -84,7 +85,7 @@ const HomeScreen: React.FC = () => {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#0F172A',
+    backgroundColor: colors.bg,
   },
   scrollContent: {
     paddingBottom: 24,
@@ -109,25 +110,25 @@ const styles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 10,
-    backgroundColor: '#1F2937',
+    backgroundColor: colors.border,
     marginRight: 12,
   },
   welcomeText: {
     fontSize: 20,
     fontWeight: '700',
-    color: '#E5E7EB',
+    color: colors.text,
   },
   levelText: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#A78BFA',
+    color: colors.purple,
   },
   playerCard: {
     flexDirection: 'row',
-    backgroundColor: '#111827',
+    backgroundColor: colors.card,
     borderRadius: 20,
     borderWidth: 1,
-    borderColor: '#1F2937',
+    borderColor: colors.border,
     padding: 20,
     marginBottom: 28,
   },
@@ -140,15 +141,15 @@ const styles = StyleSheet.create({
     height: 64,
     borderRadius: 32,
     borderWidth: 2,
-    borderColor: '#A78BFA',
+    borderColor: colors.purple,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#1F2937',
+    backgroundColor: colors.border,
   },
   avatarInitials: {
     fontSize: 22,
     fontWeight: '700',
-    color: '#E5E7EB',
+    color: colors.text,
   },
   statsSection: {
     flex: 1,
@@ -168,16 +169,16 @@ const styles = StyleSheet.create({
     marginRight: 0,
   },
   sectionCard: {
-    backgroundColor: '#111827',
+    backgroundColor: colors.card,
     borderRadius: 20,
     borderWidth: 1,
-    borderColor: '#1F2937',
+    borderColor: colors.border,
     padding: 20,
   },
   sectionTitle: {
     fontSize: 18,
     fontWeight: '700',
-    color: '#E5E7EB',
+    color: colors.text,
     marginBottom: 16,
   },
 });

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,11 @@
+export const colors = {
+  bg: '#0F172A',
+  card: '#111827',
+  border: '#1F2937',
+  text: '#E5E7EB',
+  muted: '#9CA3AF',
+  green: '#22C55E',
+  purple: '#A78BFA',
+  button: '#2563EB',
+  buttonText: '#FFFFFF',
+};


### PR DESCRIPTION
## Summary
- add a shared theme colors module with the app palette
- update home screen and UI components to consume the centralized colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15756b0908325875e62380c833565