### PR TITLE
Update sign-in screen copy and navigation behavior

### DIFF
--- a/src/screens/SignInScreen.tsx
+++ b/src/screens/SignInScreen.tsx
@@ -58,7 +58,6 @@ const SignInScreen: React.FC<SignInScreenProps> = ({ onSignIn }) => {
     setErrors(nextErrors);
 
     if (Object.keys(nextErrors).length === 0) {
-      Alert.alert('Signed in', `Welcome back, ${trimmedEmail}!`);
       onSignIn?.({ email: trimmedEmail, rememberMe });
     }
   };
@@ -75,7 +74,7 @@ const SignInScreen: React.FC<SignInScreenProps> = ({ onSignIn }) => {
               <Text style={styles.logoText}>H</Text>
             </View>
 
-            <Text style={styles.title}>Sign in to Habitica</Text>
+            <Text style={styles.title}>Sign in to HabitRPG</Text>
             <Text style={styles.subtitle}>
               Continue your adventure by accessing your character and quests.
             </Text>


### PR DESCRIPTION
## Summary
- update the sign-in headline copy to refer to HabitRPG
- allow the sign-in button to route directly to the app without the interim alert

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22c891cfc832590d3e541ecea5ca1